### PR TITLE
Add Python 3.6 and drop Python 3.3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+source = zope.deferredimport
+omit =
+   src/zope/deferredimport/samples/sample*.py
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail
+    raise AssertionError

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ parts
 docs/_build/
 .coverage
 coverage.xml
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,20 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
+    - 3.6
     - pypy
-    - pypy3
+    - pypy3.5-5.8.0
 install:
-    - pip install .
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test,docs]
 script:
-    - python setup.py -q test -q
+    - coverage run -m zope.testrunner --test-path=src
+    - coverage run -a -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctest
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,19 +1,20 @@
-Changes
-=======
+=========
+ Changes
+=========
 
 4.2.0 (unreleased)
-------------------
+==================
 
-- Add support for Python 3.5.
+- Add support for Python 3.5 and 3.6.
 
-- Drop support for Python 2.6.
+- Drop support for Python 2.6 and 3.3.
 
 - Convert doctests to Sphinx documentation, including building docs
   and running doctest snippets under ``tox``.
 
 
 4.1.0 (2014-12-26)
-------------------
+==================
 
 - Add support for PyPy.  PyPy3 support is blocked on release of fix for:
   https://bitbucket.org/pypy/pypy/issue/1946
@@ -24,7 +25,7 @@ Changes
 
 
 4.0.0 (2013-02-28)
-------------------
+==================
 
 - Add support for Python 3.3.
 
@@ -32,27 +33,27 @@ Changes
 
 
 3.5.3 (2010-09-25)
-------------------
+==================
 
 - Add test extra to declare test dependency on ``zope.testing``.
 
 
 3.5.2 (2010-05-24)
-------------------
+==================
 
 - Fix unit tests broken under Python 2.4 by the switch to the standard
   library ``doctest`` module.
 
 
 3.5.1 (2010-04-30)
-------------------
+==================
 
 - Prefer the standard library's ``doctest`` module to the one from
   ``zope.testing``.
 
 
 3.5.0 (2009-02-04)
-------------------
+==================
 
 - Add support to bootstrap on Jython.
 
@@ -60,13 +61,13 @@ Changes
 
 
 3.4.0 (2007-07-19)
-------------------
+==================
 
 - Finish release of ``zope.deferredimport``.
 
 
 3.4.0b1 (2007-07-09)
---------------------
+====================
 
 - Initial release as a separate project, corresponding to the
   ``zope.deferredimport`` from Zope 3.4.0b1.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,14 @@ include *.txt
 include *.py
 include buildout.cfg
 include tox.ini
+include .travis.yml
+include .coveragerc
 
 recursive-include src *
 
 global-exclude *.pyc
+
+recursive-include docs *.bat
+recursive-include docs *.py
+recursive-include docs *.rst
+recursive-include docs Makefile

--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,23 @@
-``zope.deferredimport``
-=======================
+=========================
+ ``zope.deferredimport``
+=========================
 
-.. image:: https://pypip.in/version/zope.deferredimport/badge.svg?style=flat
-    :target: https://pypi.python.org/pypi/zope.deferredimport/
-    :alt: Latest Version
+.. image:: https://img.shields.io/pypi/v/zope.deferredimport.svg
+        :target: https://pypi.python.org/pypi/zope.deferredimport/
+        :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.deferredimport.svg
+        :target: https://pypi.org/project/zope.deferredimport/
+        :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.deferredimport.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.deferredimport
 
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.deferredimport/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.deferredimport?branch=master
+
 .. image:: https://readthedocs.org/projects/zopedeferredimport/badge/?version=latest
-        :target: http://zopedeferredimport.readthedocs.org/en/latest/
+        :target: http://zopedeferredimport.readthedocs.io/en/latest/
         :alt: Documentation Status
 
 Often, especially for package modules, you want to import names for
@@ -19,3 +27,4 @@ in modules that will be imported from somewhere else when used.  You
 can also cause deprecation warnings to be issued when a variable is
 used.
 
+Documentation is hosted at https://zopedeferredimport.readthedocs.io/

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,5 +1,6 @@
-:mod:`zope.deferredimport` API
-==============================
+================================
+ :mod:`zope.deferredimport` API
+================================
 
 .. automodule:: zope.deferredimport
    :members:

--- a/docs/narrative.rst
+++ b/docs/narrative.rst
@@ -1,5 +1,6 @@
-Deferred Imports
-================
+==================
+ Deferred Imports
+==================
 
 .. testsetup::
 
@@ -64,7 +65,7 @@ in modules that will be imported from somewhere else when used.  You
 can also cause deprecation warnings to be issued when a variable is
 used, but we'll get to that later.
 
-The zope.deferredimport.define function can be used to define one or
+The :func:`zope.deferredimport.define` function can be used to define one or
 more names to be imported when they are accessed.  Simply provide
 names as keyword arguments with import specifiers as values.  The
 import specifiers are given as strings of the form "module:name",
@@ -278,7 +279,7 @@ modules, as in:
 
 
 Deprecation
------------
+===========
 
 Deferred attributes can also be marked as deprecated, in which case, a
 message will be printed the first time they are accessed.
@@ -311,7 +312,7 @@ warning:
     >>> zope.deferredimport.sample7.x # doctest: +NORMALIZE_WHITESPACE
     docs/narrative.rst:1: DeprecationWarning:
                 x is deprecated. Import from sample1 instead
-      Deferred Imports
+      ==================
     1
 
 but only the first time:
@@ -322,10 +323,10 @@ but only the first time:
     1
 
 Importing multiple names from the same module
----------------------------------------------
+=============================================
 
 Sometimes, you want to get multiple things from the same module.  You
-can use defineFrom or deprecatedFrom to do that:
+can use :func:`~.defineFrom` or :func:`~.deprecatedFrom` to do that:
 
 
 .. doctest::
@@ -356,7 +357,7 @@ can use defineFrom or deprecatedFrom to do that:
     >>> zope.deferredimport.sample8.q #doctest: +NORMALIZE_WHITESPACE
     docs/narrative.rst:1: DeprecationWarning:
             q is deprecated. Import from sample1 instead
-      Deferred Imports
+      ==================
     4
 
     >>> zope.deferredimport.sample8.c

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,10 @@ import os
 from setuptools import setup, find_packages
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
+        return f.read()
 
 def alltests():
-    import os
     import sys
     import unittest
     # use the zope.testrunner machinery to find all the
@@ -39,11 +39,19 @@ def alltests():
     suites = list(zope.testrunner.find.find_suites(options))
     return unittest.TestSuite(suites)
 
+TESTS_REQUIRE = [
+    'zope.testrunner',
+]
+
+DOCS_REQUIRE = [
+    'Sphinx',
+    'repoze.sphinx.autointerface',
+]
 
 setup(
     name='zope.deferredimport',
     version='4.2.0.dev0',
-    url='http://pypi.python.org/pypi/zope.deferredimport',
+    url='http://github.com/zopefoundation/zope.deferredimport',
     license='ZPL 2.1',
     description=('zope.deferredimport allows you to perform imports names '
                  'that will only be resolved when used in the code.'),
@@ -53,7 +61,7 @@ setup(
         read('README.rst')
         + '\n\n' +
         read('CHANGES.rst')
-        ),
+    ),
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -62,28 +70,29 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development',
-        ],
+    ],
     packages=find_packages('src'),
-    package_dir = {'': 'src'},
+    package_dir={'': 'src'},
     namespace_packages=['zope',],
     install_requires=[
         'setuptools',
         'zope.proxy',
-        ],
-    extras_require=dict(
-        test=[
-            ]),
-    tests_require=['zope.testrunner'],
-    test_suite = '__main__.alltests',
-    include_package_data = True,
-    zip_safe = False,
-    )
+    ],
+    extras_require={
+        'test': TESTS_REQUIRE,
+        'docs': DOCS_REQUIRE,
+    },
+    tests_require=TESTS_REQUIRE,
+    test_suite='__main__.alltests',
+    include_package_data=True,
+    zip_safe=False,
+)

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/src/zope/deferredimport/deferredmodule.py
+++ b/src/zope/deferredimport/deferredmodule.py
@@ -91,7 +91,7 @@ def initialize(level=1):
     """
     __name__ = sys._getframe(level).f_globals['__name__']
     module = sys.modules[__name__]
-    if not (type(module) is ModuleProxy):
+    if type(module) is not ModuleProxy:
         module = ModuleProxy(module)
         sys.modules[__name__] = module
 

--- a/src/zope/deferredimport/tests.py
+++ b/src/zope/deferredimport/tests.py
@@ -44,7 +44,15 @@ class DeferredTests(unittest.TestCase):
         self.assertTrue(deferred.get() is self._getTargetClass())
 
 
+class TestModuleProxy(unittest.TestCase):
+
+    def test_getattr_with_no_deferred(self):
+        from zope.deferredimport.deferredmodule import ModuleProxy
+        proxy = ModuleProxy(self)
+        with self.assertRaises(AttributeError):
+            getattr(proxy, 'no_name')
+
+
+
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(DeferredTests),
-    ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,22 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,pypy,pypy3,docs
+    py27,py34,py35,py36,pypy,pypy3,coverage
 
 [testenv]
 commands =
-    python setup.py -q test -q
+    zope-testrunner --test-path=src []
+    sphinx-build -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
 deps =
-    zope.proxy
-    zope.testrunner
+    .[test,docs]
 
 [testenv:coverage]
+usedevelop = true
 basepython =
     python2.7
 commands =
-    coverage erase
-    coverage run --source=src --omit="*sample*" setup.py -q test -q
-    coverage report --show-missing
-    coverage xml
+    coverage run -m zope.testrunner --test-path=src
+    coverage run -a -m sphinx -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
+    coverage report --fail-under=100
 deps =
     {[testenv]deps}
     coverage
@@ -27,7 +27,3 @@ basepython =
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
-deps =
-    {[testenv]deps}
-    Sphinx
-    repoze.sphinx.autointerface


### PR DESCRIPTION
- Badges.
- Run doctests on CI and tox in all versions.
- Enable coveralls
  - 100% coverage
- Minor sphinx doc cleanups (a couple of links).
- DRY dependencies.