### PR TITLE
Preserve docstrings of proxied modules. Fixes #5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - 3.5
     - 3.6
     - pypy
-    - pypy3.5-5.8.0
+    - pypy3
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 4.2.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Preserve the docstrings of proxied modules created with
+  ``deprecatedFrom``, ``deferredFrom``, etc. See `issue 5
+  <https://github.com/zopefoundation/zope.deferredimport/issues/5>`_.
 
 
 4.2.0 (2017-08-08)

--- a/src/zope/deferredimport/deferredmodule.py
+++ b/src/zope/deferredimport/deferredmodule.py
@@ -55,11 +55,12 @@ class DeferredAndDeprecated(Deferred):
 
 
 class ModuleProxy(zope.proxy.ProxyBase):
-    __slots__ = ('__deferred_definitions__', )
+    __slots__ = ('__deferred_definitions__', '__doc__')
 
     def __init__(self, module):
         super(ModuleProxy, self).__init__(module)
         self.__deferred_definitions__ = {}
+        self.__doc__ = module.__doc__
 
     def __getattr__(self, name):
         try:

--- a/src/zope/deferredimport/tests.py
+++ b/src/zope/deferredimport/tests.py
@@ -52,6 +52,17 @@ class TestModuleProxy(unittest.TestCase):
         with self.assertRaises(AttributeError):
             getattr(proxy, 'no_name')
 
+    def test_preserves_docstring(self):
+        from zope.deferredimport import deferredmodule
+
+        proxy = deferredmodule.ModuleProxy(deferredmodule)
+        self.assertEqual(deferredmodule.__doc__, proxy.__doc__)
+
+    def test_preserves_name(self):
+        from zope.deferredimport import deferredmodule
+
+        proxy = deferredmodule.ModuleProxy(deferredmodule)
+        self.assertEqual(deferredmodule.__name__, proxy.__name__)
 
 
 def test_suite():


### PR DESCRIPTION
I verified that this fixes my sphinx docs.